### PR TITLE
Change: Create "shim" exec under shims/ dir. Format of "clam.spec" file

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,15 +119,19 @@ A `clam.spec` file looks like below:
 ```
 name=foo
 version=0.1
-executables=bin/*
-resources=lib/*
+executables="bin/foo"
+librarypath="lib"
+#libraries="lib/foo.sh lib/foo/"
 ```
 
 With this `clam.spec`, `clam` installs as followings:
 
-- Copy module directory as `$CLENV_ROOT/environments/$CLENV_ENVIRONMENT/modules/foo/` directory.
-- Create symlinks of `bin/*` files in `$CLENV_ROOT/environments/$CLENV_ENVIRONMENT/bin/` directory.
-- Create symlinks of `lib/*` files in `$CLENV_ROOT/environments/$CLENV_ENVIRONMENT/lib/` directory.
+- Copy module directory as `$CLENV_ROOT/environments/$CLENV_ENVIRONMENT/modules/foo/`
+directory.
+- Create symlinks of `bin/foo` file into `$CLENV_ROOT/environments/$CLENV_ENVIRONMENT/bin/`
+directory.
+- Create symlinks of files or directories just under `lib/` into
+`$CLENV_ROOT/environments/$CLENV_ENVIRONMENT/lib/` directory.
 
 ## Install from `Clamfile`
 

--- a/bin/clenv
+++ b/bin/clenv
@@ -124,7 +124,7 @@ Help:
 
 Show version:
 
-    clenv -v|--version|version
+    clenv -v|--version
 
 =head1 DESCRIPTION
 

--- a/bin/clenv
+++ b/bin/clenv
@@ -7,6 +7,16 @@ version="0.2.2"
 source ${CLENV_ROOT}/shrc.d/clenv.shrc
 
 help() {
+  local command=${1:-}
+  if [[ ${command} ]]; then
+    command_path="$(command -v "clenv-$command" || true)"
+    if [[ "${command_path}" ]]; then
+      pod2text "${command_path}"
+      exit 1
+    else
+      echo "No such command: $command" >&2
+    fi
+  fi
   pod2text $0
   exit 1
 }
@@ -51,8 +61,8 @@ export PATH=${CLENV_ROOT}/libexec:$PATH
 command=${1:-}
 
 case "$command" in
-  "" | "-h" | "--help" )
-    help
+  "" | "-h" | "--help" | "help" )
+    help ${2:-}
     ;;
   "-v" )
     version
@@ -104,9 +114,13 @@ List environments:
 
     clenv list-env
 
+Commands:
+
+    clenv which EXECUTABLE  # Show path of EXECUTABLE in clenv
+
 Help:
 
-    clenv -h|--help|help
+    clenv -h|--help|help [COMMAND]
 
 Show version:
 

--- a/bin/clenv
+++ b/bin/clenv
@@ -22,9 +22,7 @@ help() {
 }
 
 init-env() {
-  if [[ ${CLENV_DEBUG:-} ]]; then
-    set -x
-  fi
+  [[ ${CLENV_DEBUG:-} ]] && set -x
   local _env=${1:-${__clenv_default_env}}
   local _env_dir=${__clenv_base_dir}/environments/${_env}
   if [ -d $_env_dir ]; then

--- a/bin/clenv
+++ b/bin/clenv
@@ -46,6 +46,8 @@ version() {
   fi
 }
 
+export PATH=${CLENV_ROOT}/libexec:$PATH
+
 command=${1:-}
 
 case "$command" in
@@ -58,9 +60,18 @@ case "$command" in
   "--version" )
     version --verbose
     ;;
-  * )
+  "init-env" | "list-env" )
     shift
     ${command} "$@"
+    ;;
+  * )
+    command_path="$(command -v "clenv-$command" || true)"
+    if [[ -z "${command_path}" ]]; then
+      echo "no such command - '$command'" >&2
+      exit 1
+    fi
+    shift
+    exec "${command_path}" "$@"
     ;;
 esac
 

--- a/bin/clenv
+++ b/bin/clenv
@@ -128,7 +128,10 @@ Show version:
 
 =head1 DESCRIPTION
 
-TBD.
+C<clenv> is a toolkit to organize Command-Line environments including executable
+scripts and shell resource files.
+
+See L<README.md> for more information.
 
 =head1 SEE ALSO
 

--- a/bin/clenv
+++ b/bin/clenv
@@ -114,6 +114,7 @@ List environments:
 
 Commands:
 
+    clenv exec EXECUTABLE   # Execute EXECUTABLE in clenv
     clenv which EXECUTABLE  # Show path of EXECUTABLE in clenv
 
 Help:

--- a/example/clam.spec
+++ b/example/clam.spec
@@ -1,4 +1,5 @@
 name=foo
 version=0.1
-executables=bin/*
-resources=lib/*
+executables="bin/foo bin/bar"
+librarypath="lib"
+#libraries="foo.sh lib/foo.sh"

--- a/libexec/clam-install
+++ b/libexec/clam-install
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+[[ ${CLAM_DEBUG:-} ]] && set -x
 
 source ${CLENV_ROOT}/lib/util.shrc
 source ${CLENV_ROOT}/lib/version.shrc
 source ${CLENV_ROOT}/lib/clamdb.shrc
-
-if [[ ${CLAM_DEBUG:-} ]]; then
-  set -x
-fi
 
 git_sync() {
   local _src=$1

--- a/libexec/clam-install
+++ b/libexec/clam-install
@@ -7,6 +7,9 @@ source ${CLENV_ROOT}/lib/util.shrc
 source ${CLENV_ROOT}/lib/version.shrc
 source ${CLENV_ROOT}/lib/clamdb.shrc
 
+SHIMS_DIR=${CLENV_ROOT}/shims
+SHIM_TEMPLATE=${CLENV_ROOT}/resource/shim-template
+
 git_sync() {
   local _src=$1
   local _dest=$2
@@ -206,6 +209,7 @@ install_materials() {
   local _srcs="$1"
   [[ "$_srcs" ]] || return
   local _dest=$2
+  local _shim=${3:-}
   local f _b __src_path __dest_path
 
   for x in $_srcs; do
@@ -213,7 +217,18 @@ install_materials() {
     __dest_path=${_dest}/${_b}
     __src_path=$(abspath $x)
     ln -s ${__src_path} ${__dest_path}
+    [[ -z "$_shim" ]] || create_shim "${_b}"
   done
+}
+
+create_shim() {
+  local _cmd="$1"
+  local _shim="${SHIMS_DIR}/${_cmd}"
+  [[ -x ${_shim} ]] && return
+
+  install ${SHIM_TEMPLATE} $_shim
+  echo "${_shim} created."
+  return 0
 }
 
 if [[ "${librarypath:-}" ]]; then
@@ -223,7 +238,7 @@ fi
 check_materials "${executables:-}" $bin_dir --executable
 check_materials "${libraries:-}" $lib_dir
 
-install_materials "${executables:-}" $bin_dir
+install_materials "${executables:-}" $bin_dir --shims
 install_materials "${libraries:-}" $lib_dir
 
 clamdb_add $name $version

--- a/libexec/clam-install
+++ b/libexec/clam-install
@@ -130,10 +130,15 @@ if [ -r clam.spec ];then
   unset name
   unset version
   unset executables
-  unset resources
+  unset librarypath
+  unset libraries
   source clam.spec
   name=${name:-$module}
   version=${version:-0}
+  if [[ "${librarypath:-}" && "${libraries:-}" ]]; then
+    echo "Can't specify both 'librarypath' and 'libraries' at once!" >&2
+    exit 1
+  fi
 else
   echo "clam.spec file not found! Can't install." >&2
   cleanup
@@ -165,25 +170,61 @@ cleanup
 bin_dir=${CLENV_ROOT}/environments/${CLENV_ENVIRONMENT}/bin
 lib_dir=${CLENV_ROOT}/environments/${CLENV_ENVIRONMENT}/lib
 
-install_materials() {
-  local _src=$1
+check_materials() {
+  local _srcs="$1"
+  [[ "$_srcs" ]] || return
   local _dest=$2
-  local f __path
+  local _type=${3:-}
+  local err f _b __dest_path
 
-  if [[ $_src ]]; then
-    for f in $(\ls -1 $_src); do
-      if [ -f $f ]; then
-        __path=$(abspath $f)
-        ln -s ${__path} ${_dest}/
-      else
-        echo "Not exist $f Skip." >&2
+  for f in $_srcs; do
+    if [[ $_type = "--executable" ]]; then
+      if [[ ! -x $f ]]; then
+        err=1
+        echo "[Error] Not executable $f." >&2
+        continue
       fi
-    done
-  fi
+    elif [[ ! -e $f ]]; then
+      err=1
+      echo "[Error] Not exit $f." >&2
+      continue
+    fi
+
+    _b=${f##*/}
+    __dest_path=${_dest}/${_b}
+    if [[ -e ${__dest_path} ]]; then
+      err=1
+      echo "[Error] Some file already exists at install path! ${__dest_path}" >&2
+      continue
+    fi
+  done
+
+  [[ -z "${err:-}" ]] || exit 1
 }
 
+install_materials() {
+  local _srcs="$1"
+  [[ "$_srcs" ]] || return
+  local _dest=$2
+  local f _b __src_path __dest_path
+
+  for x in $_srcs; do
+    _b=${x##*/}
+    __dest_path=${_dest}/${_b}
+    __src_path=$(abspath $x)
+    ln -s ${__src_path} ${__dest_path}
+  done
+}
+
+if [[ "${librarypath:-}" ]]; then
+  libraries="$(echo $(find $librarypath -mindepth 1 -maxdepth 1))"
+fi
+
+check_materials "${executables:-}" $bin_dir --executable
+check_materials "${libraries:-}" $lib_dir
+
 install_materials "${executables:-}" $bin_dir
-install_materials "${resources:-}" $lib_dir
+install_materials "${libraries:-}" $lib_dir
 
 clamdb_add $name $version
 

--- a/libexec/clenv-exec
+++ b/libexec/clenv-exec
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+[[ ${CLENV_DEBUG:-} ]] && set -x
+
+CLENV_COMMAND="$1"
+
+if [[ -z "${CLENV_COMMAND}" ]]; then
+  pod2text $0 >&2
+  exit 1
+fi
+
+CLENV_COMMAND_PATH="$(clenv-which "${CLENV_COMMAND}")"
+CLENV_COMMAND_DIR="${CLENV_COMMAND_PATH%/*}"
+
+shift
+export PATH="${CLENV_COMMAND_DIR}:$PATH"
+
+exec -a "${CLENV_COMMAND}" "${CLENV_COMMAND_PATH}" "$@"
+
+: <<'__EOF__'
+
+=encoding utf8
+
+=head1 NAME
+
+B<clenv-exec> - Execute command in clenv
+
+=head1 SYNOPSYS
+
+    clenv-exec COMMAND
+
+=head1 DESCRIPTION
+
+This command executes target command in C<clenv> environment.
+
+=head1 AUTHORS
+
+IKEDA Kiyoshi E<lt>yasutake.kiyoshi@gmail.comE<gt>
+
+=head1 LICENSE
+
+The MIT License (MIT)
+
+Copyright (c) 2016 IKEDA Kiyoshi
+
+=cut
+
+__EOF__
+

--- a/libexec/clenv-which
+++ b/libexec/clenv-which
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CLENV_COMMAND="${1:-}"
+
+if [[ -z "${CLENV_COMMAND}" ]]; then
+  pod2text $0 >&2
+  exit 1
+fi
+
+if [[ -z "${CLENV_ENVIRONMENT}" ]]; then
+  echo "clenv not initialized yet! Run 'clenv init-env' at first." >&2
+  exit 1
+fi
+
+CLENV_COMMAND_PATH="${CLENV_ROOT}/environments/${CLENV_ENVIRONMENT}/bin/${CLENV_COMMAND}"
+
+if [[ -x "${CLENV_COMMAND_PATH}" ]]; then
+  echo "${CLENV_COMMAND_PATH}"
+else
+  echo "clenv: ${CLENV_COMMAND} - command not found." >&2
+  exit 2
+fi
+
+exit 0
+
+: <<'__EOF__'
+
+=encoding utf8
+
+=head1 NAME
+
+B<clenv-which> - Search and show command path in clenv
+
+=head1 SYNOPSYS
+
+    clenv-which COMMAND
+
+=head1 DESCRIPTION
+
+This command searches and shows command path in C<clenv> environment.
+
+=head1 AUTHORS
+
+IKEDA Kiyoshi E<lt>yasutake.kiyoshi@gmail.comE<gt>
+
+=head1 LICENSE
+
+The MIT License (MIT)
+
+Copyright (c) 2016 IKEDA Kiyoshi
+
+=cut
+
+__EOF__
+

--- a/libexec/clenv-which
+++ b/libexec/clenv-which
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+[[ ${CLENV_DEBUG:-} ]] && set -x
 
 CLENV_COMMAND="${1:-}"
 

--- a/resource/shim-template
+++ b/resource/shim-template
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+[[ ${CLENV_DEBUG:-} ]] && set -x
+
+program="${0##*/}"
+
+exec "${CLENV_ROOT}/bin/clenv" exec "$program" "$@"

--- a/shrc.d/clenv.shrc
+++ b/shrc.d/clenv.shrc
@@ -15,10 +15,6 @@ clenv_switch() {
     return 1
   fi
   export CLENV_ENVIRONMENT=$_env
-  if [ -s ${__clenv_base_dir}/shims ]; then
-    rm -f ${__clenv_base_dir}/shims
-  fi
-  ln -sf ${_env_dir}/bin ${__clenv_base_dir}/shims
   if [ "$prev_clenv" ]; then
     cload_path_del ${__clenv_base_dir}/environments/${prev_clenv}/lib
   fi

--- a/t/clenv.t
+++ b/t/clenv.t
@@ -33,8 +33,6 @@ EOLIB
   t_substart "clenv_switch"
   clenv_switch test1
   t_is $CLENV_ENVIRONMENT "test1" "switch to test1"
-  _link=$(readlink ${__clenv_base_dir}/shims)
-  t_is $_link "${__clenv_base_dir}/environments/test1/bin" "shims linked to test1/bin"
   t_subclose
 )
 t_subend "clenv_switch"
@@ -42,8 +40,6 @@ t_subend "clenv_switch"
 T_SUB "clenv_use" ((
   clenv_use test2
   t_is $CLENV_ENVIRONMENT "test2" "switch to test2"
-  _link=$(readlink ${__clenv_base_dir}/shims)
-  t_is $_link "${__clenv_base_dir}/environments/test2/bin" "shims linked to test2/bin"
   t_is $__test2_foo "TEST2_FOO" "library loaded"
 ))
 


### PR DESCRIPTION
This PR has big breaking change. Take care.
### Changes

[clenv] Directory structure:
- `shims` is no symlink now. It's a directory which contains "shim" executable files like those in rbenv or in plenv.

clam.spec:
- Obsolete `resources`.
- Add new fields: `librarypath` or `libraries`
  - `libraries` is almost same as `resources`. But you can't use glob `*` any longer.
- You can't use glob `*` for `executables` field, too.
### Internal changes

clenv:
- Add sobcommands `which` and `exec` similar to ones in rbenv or plenv.
