### PR TITLE
Remove "clenv_switch". Change "clenv_use" not to load libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,27 +69,17 @@ clenv init-env [$env]
 This command creates `$CLENV_ROOT/environments/$env`.  
 Default `$env` is `"default"`.
 
-And to use `clam` modules in the environment, run either of following shell functions:
+And to use `clam` modules in the environment, run following shell function:
 
 ```sh
-# Switch symlinks
-clenv_switch $env
-# Load libraries in addition
 clenv_use $env
 ```
 
-`clenv_switch $env` does followings:
+This function does followings:
 
 - Set environment variable `CLENV_ENVIRONMENT` to `$env`.
-- Create symlink `$CLENV_ROOT/shims` of `$CLENV_ROOT/environments/$CLENV_ENVIRONMENT/bin`.
-
-`clenv_use $env` does followings **in addition** to `clenv_switch $env`:
-
-- Load shell resources by `source` command which are in
-  `$CLENV_ROOT/environments/$CLENV_ENVIRONMENT/lib` directory.
-
-To use `clenv_use` or `clenv_switch` is your choice.  
-Use one which you prefer.
+- Add `$CLENV_ROOT/environments/$env/lib` to `CLOAD_PATH` environment variable.
+See [cload](#cload) section for `CLOAD_PATH`.
 
 # clam
 

--- a/bin/clenv
+++ b/bin/clenv
@@ -102,11 +102,7 @@ Initialize an environment:
 Switch environments:
 
     . shrc.d/clenv.shrc
-
-    # switch and load libraries
     clenv_use $env
-    # only switch
-    clenv_switch $env
 
 List environments:
 

--- a/shrc.d/clenv.shrc
+++ b/shrc.d/clenv.shrc
@@ -2,10 +2,8 @@ __clenv_default_env="default"
 __clenv_base_dir=${CLENV_ROOT:-"$HOME/.clenv"}
 . ${__clenv_base_dir}/shrc.d/cload.shrc
 
-clenv_switch() {
-  if [ "${CLENV_DEBUG:-}" ]; then
-    set -x
-  fi
+clenv_use() {
+  [ "${CLENV_DEBUG:-}" ] && set -x
   local prev_clenv=${CLENV_ENVIRONMENT:-}
   local _env=${1:-${__clenv_default_env}}
   local _env_dir=${__clenv_base_dir}/environments/${_env}
@@ -22,17 +20,6 @@ clenv_switch() {
   set +x
 }
 
-clenv_use() {
-  local _env=${1:-${__clenv_default_env}}
-  local _env_dir=${__clenv_base_dir}/environments/${_env}
-  clenv_switch $_env
-  local _lib_dir=${_env_dir}/lib
-  local rc
-  for rc in $(ls $_lib_dir/); do
-    . $_lib_dir/$rc
-  done
-}
-
 : <<'__EOF__'
 
 =encoding utf8
@@ -47,10 +34,7 @@ B<clenv.shrc> - Provides shell functions for C<clenv>
 
 Switch environments:
 
-    # switch and load libraries
     clenv_use $env
-    # only switch
-    clenv_switch $env
 
 =head1 DESCRIPTION
 

--- a/t/clenv.t
+++ b/t/clenv.t
@@ -25,22 +25,10 @@ for i in 1 2; do
     mkdir -p $__clenv_base_dir/environments/test$i/$dir
   done
 done
-cat <<EOLIB > $__clenv_base_dir/environments/test2/lib/foo.shrc
-__test2_foo="TEST2_FOO"
-EOLIB
-
-(
-  t_substart "clenv_switch"
-  clenv_switch test1
-  t_is $CLENV_ENVIRONMENT "test1" "switch to test1"
-  t_subclose
-)
-t_subend "clenv_switch"
 
 T_SUB "clenv_use" ((
   clenv_use test2
   t_is $CLENV_ENVIRONMENT "test2" "switch to test2"
-  t_is $__test2_foo "TEST2_FOO" "library loaded"
 ))
 
 rm -rf $__clenv_base_dir


### PR DESCRIPTION
Because we have `cload` now, we don't need this function any longer.
